### PR TITLE
Fix for Clamp on diffuse ramp textures

### DIFF
--- a/SpriteShaders/CGIncludes/SpriteLighting.cginc
+++ b/SpriteShaders/CGIncludes/SpriteLighting.cginc
@@ -143,7 +143,7 @@ inline fixed3 calculateRampedDiffuse(fixed3 lightColor, float attenuation, float
 {
 	float d = angleDot * 0.5 + 0.5;
 #if defined(HARD_DIFFUSE_RAMP)
-	half3 ramp = calculateDiffuseRamp(d * attenuation * 2);
+	half3 ramp = calculateDiffuseRamp(d * attenuation * 2 - 1);
 	return lightColor * ramp;
 #else
 	half3 ramp = calculateDiffuseRamp(d);


### PR DESCRIPTION
This is a simple fix for an issue we were having with the Diffuse Ramp option, when using clamped textures. When the lighting was zero, the texture would wrap around to the other side of the diffuse ramp, resulting in errors in the parts facing away from the light.

![plane_guy](https://cloud.githubusercontent.com/assets/24752/25461483/2d928590-2a9e-11e7-8dc4-2c70c7e2be7c.png)

The obvious fix for this was to enable clamp in the texture mode, but that didn't work at all. It turned out the diffuse ramp in the shader was accidentally sampling the UV range from 1.0 .. 2.0.

This fixes the range and brings it back to 0.0 .. 1.0, so clamp textures can be used. (Top row in example is current shader, bottom row is with this fix applied).

Thank you!

